### PR TITLE
Build es5 on prepare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,186 +36,187 @@
       "dev": true
     },
     "@webassemblyjs/ast": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.5.10.tgz",
-      "integrity": "sha512-4BObuKRfeAnKdz5PfTp6MqSoCdj0z9EXu00PsQLzqcC55Htw5r9OXebS+sPF8T5tRTRI5/2w0CR52s/4vJ2fkw==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.5.12.tgz",
+      "integrity": "sha512-bmTBEKuuhSU6dC95QIW250xO769cdYGx9rWn3uBLTw2pUpud0Z5kVuMw9m9fqbNzGeuOU2HpyuZa+yUt2CTEDA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/helper-module-context": "1.5.10",
-        "@webassemblyjs/helper-wasm-bytecode": "1.5.10",
-        "@webassemblyjs/wast-parser": "1.5.10",
+        "@webassemblyjs/helper-module-context": "1.5.12",
+        "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
+        "@webassemblyjs/wast-parser": "1.5.12",
         "debug": "^3.1.0",
         "mamacro": "^0.0.3"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.5.10.tgz",
-      "integrity": "sha512-ns6H/06BTnk7thnN8O6MK9xMqodgaVKkjBaC8nXGLeAtX2ONHxQL2NnY4XgUzyo7yRwGVAPBxdl7yxzc0iy9Eg==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.5.12.tgz",
+      "integrity": "sha512-epTvkdwOIPpTE9edHS+V+shetYzpTbd91XOzUli1zAS0+NSgSe6ZsNggIqUNzhma1s4bN2f/m8c6B1NMdCERAg==",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.5.10.tgz",
-      "integrity": "sha512-OeWjB1Ie44sg5Nr8GVot5l+uclK4fWEQGH1b+HQ7x9GN9UxcJUIG3+u5dj2MTkthneQT1hUo09Wtpb/bY7zfXA==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.5.12.tgz",
+      "integrity": "sha512-Goxag86JvLq8ucHLXFNSLYzf9wrR+CJr37DsESTAzSnGoqDTgw5eqiXSQVd/D9Biih7+DIn8UIQCxMs8emRRwg==",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.5.10.tgz",
-      "integrity": "sha512-soggPYDku3gDl+zV1TVle3zLWgiU1Kli4QJdWCoeyX95RhGtF2A5tP7U3ypLlBb74SdoYYFVn3Fm7HXIWj1wzA==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.5.12.tgz",
+      "integrity": "sha512-tJNUjttL5CxiiS/KLxT4/Zk0Nbl/poFhztFxktb46zoQEUWaGHR9ZJ0SnvE7DbFX5PY5JNJDMZ0Li4lm246fWw==",
       "dev": true,
       "requires": {
         "debug": "^3.1.0"
       }
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.5.10.tgz",
-      "integrity": "sha512-1mNetGdoMMSW+spR7eC5kJZCA8g9aK7G0t2Mc5Q0p9Kw8p+gFgf9dO7fbThHP/+tNLHM6+SwUQ+S8s4BLhBtZQ==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.5.12.tgz",
+      "integrity": "sha512-0FrJgiST+MQDMvPigzs+UIk1vslLIqGadkEWdn53Lr0NsUC2JbheG9QaO3Zf6ycK2JwsHiUpGaMFcHYXStTPMA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/wast-printer": "1.5.10"
+        "@webassemblyjs/wast-printer": "1.5.12"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.5.10.tgz",
-      "integrity": "sha512-ekKmiumHOJrlzZhrigZ19COsCbqNeHtnRN2wktMIaCHGobW/FW+d4Qv1svc0BetjoXo/DhSgVvhHoxaKSO3yPw==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.5.12.tgz",
+      "integrity": "sha512-QBHZ45VPUJ7UyYKvUFoaxrSS9H5hbkC9U7tdWgFHmnTMutkXSEgDg2gZg3I/QTsiKOCIwx4qJUJwPd7J4D5CNQ==",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.5.10.tgz",
-      "integrity": "sha512-ce2KTWDlSCHhJZMOX+bgHGIKwYsx27MWySqffl8pqu9K+M1G4TlZCfRlN1dV85rAhn5OknOAHRBmRtceklY2/g==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.5.12.tgz",
+      "integrity": "sha512-SCXR8hPI4JOG3cdy9HAO8W5/VQ68YXG/Hfs7qDf1cd64zWuMNshyEour5NYnLMVkrrtc0XzfVS/MdeV94woFHA==",
       "dev": true,
       "requires": {
+        "debug": "^3.1.0",
         "mamacro": "^0.0.3"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.5.10.tgz",
-      "integrity": "sha512-0noYMZDkkUZvHNpcOp9+ElMTwPxIyEWVc1bdjJ38qZTIX9ytCgRifs2DrF/1FfUxzI3d3xXFqrqCFfp+amAOaA==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.5.12.tgz",
+      "integrity": "sha512-0Gz5lQcyvElNVbOTKwjEmIxGwdWf+zpAW/WGzGo95B7IgMEzyyfZU+PrGHDwiSH9c0knol9G7smQnY0ljrSA6g==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.5.10.tgz",
-      "integrity": "sha512-rXH6br9w+CYY/tN+N7MFmnUD5J/D4sBsl1K8liqKGpAXlsGp9SmEeqXy8yBWJ1wH3J3rNGaxQNbk9VR3qZgn0w==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.5.12.tgz",
+      "integrity": "sha512-ge/CKVKBGpiJhFN9PIOQ7sPtGYJhxm/mW1Y3SpG1L6XBunfRz0YnLjW3TmhcOEFozIVyODPS1HZ9f7VR3GBGow==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.5.10",
-        "@webassemblyjs/helper-buffer": "1.5.10",
-        "@webassemblyjs/helper-wasm-bytecode": "1.5.10",
-        "@webassemblyjs/wasm-gen": "1.5.10",
+        "@webassemblyjs/ast": "1.5.12",
+        "@webassemblyjs/helper-buffer": "1.5.12",
+        "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
+        "@webassemblyjs/wasm-gen": "1.5.12",
         "debug": "^3.1.0"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.5.10.tgz",
-      "integrity": "sha512-WWlO5quQd3qOUT4wJiuodh5E1A8BfXYkOueuZZjEPL3budH5snqdWsPDieTqkBJnfCZGwRkRSn14OH4OPY1hsw==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.5.12.tgz",
+      "integrity": "sha512-F+PEv9QBzPi1ThLBouUJbuxhEr+Sy/oua1ftXFKHiaYYS5Z9tKPvK/hgCxlSdq+RY4MSG15jU2JYb/K5pkoybg==",
       "dev": true,
       "requires": {
         "ieee754": "^1.1.11"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.5.10.tgz",
-      "integrity": "sha512-b+DWTy6RsRznpCKvsP3V5yNkk6YWs+7kLOJ3GU1ITyz846VIzVJda+K0mr31fgXzob/QWToWEx8ajk+PrOegkQ==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.5.12.tgz",
+      "integrity": "sha512-cCOx/LVGiWyCwVrVlvGmTdnwHzIP4+zflLjGkZxWpYCpdNax9krVIJh1Pm7O86Ox/c5PrJpbvZU1cZLxndlPEw==",
       "dev": true,
       "requires": {
         "leb": "^0.3.0"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.5.10.tgz",
-      "integrity": "sha512-MQM04pZd0DoxukOPBJD4uaeVQ4iaWzRqsq7iDvJQBqcxIIEwi2iAPv+xjL2PbVwosCvwkh7FzKK3FHVQUjTlTQ==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.5.12.tgz",
+      "integrity": "sha512-FX8NYQMiTRU0TfK/tJVntsi9IEKsedSsna8qtsndWVE0x3zLndugiApxdNMIOoElBV9o4j0BUqR+iwU58QfPxQ==",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.5.10.tgz",
-      "integrity": "sha512-mrMZw5A0+p6A58iquzq/d0SJej481H4pNwPO65rEjzDsHs+yykT6de26VQD2GtaCTThfSNcw3JJXWJ1biqO/+g==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.5.12.tgz",
+      "integrity": "sha512-r/oZAyC4EZl0ToOYJgvj+b0X6gVEKQMLT34pNNbtvWBehQOnaSXvVUA5FIYlH8ubWjFNAFqYaVGgQTjR1yuJdQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.5.10",
-        "@webassemblyjs/helper-buffer": "1.5.10",
-        "@webassemblyjs/helper-wasm-bytecode": "1.5.10",
-        "@webassemblyjs/helper-wasm-section": "1.5.10",
-        "@webassemblyjs/wasm-gen": "1.5.10",
-        "@webassemblyjs/wasm-opt": "1.5.10",
-        "@webassemblyjs/wasm-parser": "1.5.10",
-        "@webassemblyjs/wast-printer": "1.5.10",
+        "@webassemblyjs/ast": "1.5.12",
+        "@webassemblyjs/helper-buffer": "1.5.12",
+        "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
+        "@webassemblyjs/helper-wasm-section": "1.5.12",
+        "@webassemblyjs/wasm-gen": "1.5.12",
+        "@webassemblyjs/wasm-opt": "1.5.12",
+        "@webassemblyjs/wasm-parser": "1.5.12",
+        "@webassemblyjs/wast-printer": "1.5.12",
         "debug": "^3.1.0"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.5.10.tgz",
-      "integrity": "sha512-MXYoZg7zaRGmU2h2FBa6Oo+y0etuDZycx0h7nrBD4LzVqhufenoWY4Be6K4IMU0L/fRb/GMp17Vfqg4m/J8EuQ==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.5.12.tgz",
+      "integrity": "sha512-LTu+cr1YRxGGiVIXWhei/35lXXEwTnQU18x4V/gE+qCSJN21QcVTMjJuasTUh8WtmBZtOlqJbOQIeN7fGnHWhg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.5.10",
-        "@webassemblyjs/helper-wasm-bytecode": "1.5.10",
-        "@webassemblyjs/ieee754": "1.5.10",
-        "@webassemblyjs/leb128": "1.5.10",
-        "@webassemblyjs/utf8": "1.5.10"
+        "@webassemblyjs/ast": "1.5.12",
+        "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
+        "@webassemblyjs/ieee754": "1.5.12",
+        "@webassemblyjs/leb128": "1.5.12",
+        "@webassemblyjs/utf8": "1.5.12"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.5.10.tgz",
-      "integrity": "sha512-1A1rVPa1URgjCmEVZupRgrrbqwfCh6hJVkogK22JNygS+wn1gg1jgjN82Zd3NDhm738TwY61936n3y25GC+mfQ==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.5.12.tgz",
+      "integrity": "sha512-LBwG5KPA9u/uigZVyTsDpS3CVxx3AePCnTItVL+OPkRCp5LqmLsOp4a3/c5CQE0Lecm0Ss9hjUTDcbYFZkXlfQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.5.10",
-        "@webassemblyjs/helper-buffer": "1.5.10",
-        "@webassemblyjs/wasm-gen": "1.5.10",
-        "@webassemblyjs/wasm-parser": "1.5.10",
+        "@webassemblyjs/ast": "1.5.12",
+        "@webassemblyjs/helper-buffer": "1.5.12",
+        "@webassemblyjs/wasm-gen": "1.5.12",
+        "@webassemblyjs/wasm-parser": "1.5.12",
         "debug": "^3.1.0"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.5.10.tgz",
-      "integrity": "sha512-VWSi7NWmfEuMpZ0+CTnBzz8qhxw7R17CwmbcJ+QJ0wfqReWEgP/J5yI4mN/C/lEoYuroFUF+sTWoDQqzH4FNdQ==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.5.12.tgz",
+      "integrity": "sha512-xset3+1AtoFYEfMg30nzCGBnhKmTBzbIKvMyLhqJT06TvYV+kA884AOUpUvhSmP6XPF3G+HVZPm/PbCGxH4/VQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.5.10",
-        "@webassemblyjs/helper-api-error": "1.5.10",
-        "@webassemblyjs/helper-wasm-bytecode": "1.5.10",
-        "@webassemblyjs/ieee754": "1.5.10",
-        "@webassemblyjs/leb128": "1.5.10",
-        "@webassemblyjs/wasm-parser": "1.5.10"
+        "@webassemblyjs/ast": "1.5.12",
+        "@webassemblyjs/helper-api-error": "1.5.12",
+        "@webassemblyjs/helper-wasm-bytecode": "1.5.12",
+        "@webassemblyjs/ieee754": "1.5.12",
+        "@webassemblyjs/leb128": "1.5.12",
+        "@webassemblyjs/utf8": "1.5.12"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.5.10.tgz",
-      "integrity": "sha512-RORXT40qjkFgowmFzqGFGBW3fuNd7UKJwyuYXeXLzqQOoPBySE1lsSrku0aQIcVl086dy297A+De5vPCfF/Rfg==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.5.12.tgz",
+      "integrity": "sha512-QWUtzhvfY7Ue9GlJ3HeOB6w5g9vNYUUnG+Y96TWPkFHJTxZlcvGfNrUoACCw6eDb9gKaHrjt77aPq41a7y8svg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.5.10",
-        "@webassemblyjs/floating-point-hex-parser": "1.5.10",
-        "@webassemblyjs/helper-api-error": "1.5.10",
-        "@webassemblyjs/helper-code-frame": "1.5.10",
-        "@webassemblyjs/helper-fsm": "1.5.10",
+        "@webassemblyjs/ast": "1.5.12",
+        "@webassemblyjs/floating-point-hex-parser": "1.5.12",
+        "@webassemblyjs/helper-api-error": "1.5.12",
+        "@webassemblyjs/helper-code-frame": "1.5.12",
+        "@webassemblyjs/helper-fsm": "1.5.12",
         "long": "^3.2.0",
         "mamacro": "^0.0.3"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.5.10.tgz",
-      "integrity": "sha512-n4zZJmnETVc4RRs9wAZQr3dXUwC+Yyx+xwkaWdTk36NqgM89CPVLBpw8htKyKG+BX/tgk+VOXRwO+1x5Cf3J8Q==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.5.12.tgz",
+      "integrity": "sha512-XF9RTeckFgDyl196uRKZWHFFfbkzsMK96QTXp+TC0R9gsV9DMiDGMSIllgy/WdrZ3y3dsQp4fTA5r4GoaOBchA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.5.10",
-        "@webassemblyjs/wast-parser": "1.5.10",
+        "@webassemblyjs/ast": "1.5.12",
+        "@webassemblyjs/wast-parser": "1.5.12",
         "long": "^3.2.0"
       }
     },
@@ -1682,6 +1683,14 @@
         "ssri": "^5.2.4",
         "unique-filename": "^1.1.0",
         "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "dev": true
+        }
       }
     },
     "cache-base": {
@@ -1760,9 +1769,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000850",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000850.tgz",
-      "integrity": "sha512-iHK48UR/InydhpPAzgSmsJXRAR925T0kwJhZ1wk0xRatpGMvi2f06LABg6HXfV4WW4P2wChzlcFa/TEmbTyXQA==",
+      "version": "1.0.30000852",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000852.tgz",
+      "integrity": "sha512-NOuitABlrRbIpjtC8HdDnHL9Fi+yH5phDoXlXT7Im++48kll2bUps9dWWdAnBwqT/oEsjobuOLnnJCBjVqadCw==",
       "dev": true
     },
     "chai": {
@@ -1829,10 +1838,13 @@
       "dev": true
     },
     "chrome-trace-event": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-0.1.3.tgz",
-      "integrity": "sha512-sjndyZHrrWiu4RY7AkHgjn80GfAM2ZSzUkZLV/Js59Ldmh6JDThf0SUmOHU53rFu2rVxxfCzJ30Ukcfch3Gb/A==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
+      "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -2043,18 +2055,18 @@
       }
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.1"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
       "dev": true
     },
     "colors": {
@@ -3466,9 +3478,9 @@
       "dev": true
     },
     "fbjs": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
-      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
       "dev": true,
       "requires": {
         "core-js": "^1.0.0",
@@ -3477,7 +3489,7 @@
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.9"
+        "ua-parser-js": "^0.7.18"
       },
       "dependencies": {
         "core-js": {
@@ -4593,9 +4605,9 @@
       }
     },
     "hash.js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
+      "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.0"
@@ -4664,9 +4676,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
       "dev": true
     },
     "iferr": {
@@ -5376,9 +5388,9 @@
           }
         },
         "rxjs": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.0.tgz",
-          "integrity": "sha512-qBzf5uu6eOKiCZuAE0SgZ0/Qp+l54oeVxFfC2t+mJ2SFI6IB8gmMdJHs5DUMu5kqifqcCtsKS2XHjhZu6RKvAw==",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz",
+          "integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
           "dev": true,
           "requires": {
             "tslib": "^1.9.0"
@@ -6728,9 +6740,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.4.tgz",
-      "integrity": "sha512-emsEZ2bAigL1lq6ssgkpPm1MIBqgeTvcp90NxOP5XDqprub/V/WS2Hfgih3mS7/1dqTUvhG+sxx1Dv8crnVexA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.5.tgz",
+      "integrity": "sha512-4M90mfvLz6yRf2Dhzd+xPIE6b4xkI8nHMJhsSm9IlfG17g6wujrrm7+H1X8x52tC4cSNm6HmuhCUSNe6Hd5wfw==",
       "dev": true
     },
     "pretty-bytes": {
@@ -7296,14 +7308,14 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
-          "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
+          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0",
+            "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.1"
           }
         },
@@ -7317,6 +7329,12 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
           "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         }
       }
@@ -8807,21 +8825,21 @@
       }
     },
     "webpack": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.11.1.tgz",
-      "integrity": "sha512-8HGSxsLm9LTVgYiyfjY849c3Rgtb0bI0fPpdQsMmO6Hg8JXUOCudGD3j6sPfo6DaAdti1icUUZNh8XpY3igHqQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.12.0.tgz",
+      "integrity": "sha512-EJj2FfhgtjrTbJbJaNulcVpDxi9vsQVvTahHN7xJvIv6W+k4r/E6Hxy4eyOrj+IAFWqYgaUtnpxmSGYP8MSZJw==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.5.10",
-        "@webassemblyjs/helper-module-context": "1.5.10",
-        "@webassemblyjs/wasm-edit": "1.5.10",
-        "@webassemblyjs/wasm-opt": "1.5.10",
-        "@webassemblyjs/wasm-parser": "1.5.10",
-        "acorn": "^5.0.0",
+        "@webassemblyjs/ast": "1.5.12",
+        "@webassemblyjs/helper-module-context": "1.5.12",
+        "@webassemblyjs/wasm-edit": "1.5.12",
+        "@webassemblyjs/wasm-opt": "1.5.12",
+        "@webassemblyjs/wasm-parser": "1.5.12",
+        "acorn": "^5.6.2",
         "acorn-dynamic-import": "^3.0.0",
         "ajv": "^6.1.0",
         "ajv-keywords": "^3.1.0",
-        "chrome-trace-event": "^0.1.1",
+        "chrome-trace-event": "^1.0.0",
         "enhanced-resolve": "^4.0.0",
         "eslint-scope": "^3.7.1",
         "json-parse-better-errors": "^1.0.2",
@@ -8840,14 +8858,14 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
-          "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
+          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0",
+            "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.1"
           }
         },
@@ -9117,6 +9135,12 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "kind-of": {
@@ -9450,9 +9474,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {
@@ -9479,14 +9503,6 @@
         "which-module": "^2.0.0",
         "y18n": "^3.2.1",
         "yargs-parser": "^9.0.2"
-      },
-      "dependencies": {
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        }
       }
     },
     "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint src",
     "testrpc": "ganache-cli -p 7545 -i 5777",
     "test": "mocha --require babel-register",
-    "prepublish": "npm run build"
+    "prepare": "npm run build:es5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Replace `prepublish` with `prepare`. Should fix `require('linnia')` not working when linnia-js being npm installed from git.
Remove webpack browser build on `prepare`