### PR TITLE
Add record.reencrypt

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -182,7 +182,7 @@ Gets the plaintext data of the record
 
 ### Parameters
 1. `Buffer|String` - The private key to decrypt the data
-1. `(String) => (Promise<Buffer>)` - A function to resolve the data URI. The parameter is the hex data URI. The function should return the encrypted data in a buffer.
+1. `(String) => (Promise<Buffer>)` - A function to resolve the data URI. The parameter is the string data URI. The function should return the encrypted data in a buffer.
 
 ### Returns
 `Promise<Buffer>` - The plaintext data
@@ -200,6 +200,20 @@ linnia.decryptData(privKey, (dataUri) => {
 })
 ```
 
+## record.decryptPermissioned
+```javascript
+record.decryptPerissioned(viewerAddress, privKey, uriResolver)
+```
+Gets the plaintext data of a permissioned copy of the record
+
+### Parameters
+1. `String` - The address of viewer
+1. `Buffer|String` - The private key to decrypt the data of the permissioned copy. Note that this is the key controlled by the viewer, not the record owner.
+1. `(String) => (Promise<Buffer>)` - A function to resolve the data URI. The parameter is the string data URI. The function should return the encrypted data in a buffer.
+
+### Returns
+`Promise<Buffer>` - The plaintext data
+
 ## record.verifyData
 ```javascript
 record.verifyData(plaintext)
@@ -212,19 +226,19 @@ Verifies the hash of the data against the one in Linnia.
 ### Returns
 `Boolean` - True if hash matches
 
-## record.decryptPermissioned
+## record.reencryptData
 ```javascript
-record.decryptPerissioned(viewerAddress, privKey, uriResolver)
+record.reencryptData(pubKey, privKey, uriResolver)
 ```
-Gets the plaintext data of a permissioned copy of the record
+Re-encrypts the data to another public key
 
 ### Parameters
-1. `String` - The address of viewer
-1. `Buffer|String` - The private key to decrypt the data of the permissioned copy. Note that this is the key controlled by the viewer, not the record owner.
-1. `(String) => (Promise<Buffer>)` - A function to resolve the data URI. The parameter is the hex data URI. The function should return the encrypted data in a buffer.
+1. `Buffer|String` - Public key to re-encrypt the data to
+1. `Buffer|String` - Private key to decrypt the record data. This should be a key controlled by the record owner
+1. `(String) => (Promise<Buffer>)` - A function to resolve the data URI. The parameter is the string data URI. The function should return the encrypted data in a buffer.
 
 ### Returns
-`Promise<Buffer>` - The plaintext data
+`Buffer` - The re-encrypted data
 
 ---
 # Utility functions

--- a/src/record.js
+++ b/src/record.js
@@ -82,6 +82,18 @@ class Record {
     return eutil.bufferToHex(eutil.keccak256(plaintext)) === this.dataHash;
   }
 
+  /**
+   * Re-encrypts the data to another public key
+   * @param {Buffer|String} pubKey Public key to re-encrypt the data to
+   * @param {BUffer|String} privKey Private key to decrypt the record data
+   * @param {Function} uriResolver Async function that takes a data URI string and returns the data
+   * @returns {Buffer} Re-encrypted data
+   */
+  async reencryptData(pubKey, privKey, uriResolver) {
+    const plaintext = await this.decryptData(privKey, uriResolver);
+    return _util.encrypt(pubKey, plaintext);
+  }
+
   static async fromContract(recordsContract, permissionsContract, dataHash) {
     const r = await _recordsFunctions.getRecord(recordsContract, dataHash);
     const contracts = {


### PR DESCRIPTION
Not sure if this is a good idea though

Alice can reencrypt the record data to Bob like
```javascript
record.reencrypt(bobPubKey, alicePrivKey, uriResolver)
```

Also it's kind of nasty to fetch the data every time. Maybe create a `RecordData` class to cache the plaintext/ciphertext?