### PR TITLE
Update config.yml to use npm ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.11
+      - image: circleci/node:10.5
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable

`If dependencies in the package lock do not match those in package.json, npm ci will exit with an error, instead of updating the package lock.`